### PR TITLE
Found one bug: Ordering file search results deviated from input patterns (each pattern being a test file pattern CLI argument)

### DIFF
--- a/tests/JTest.UnitTests/TestFileSearcherTests.cs
+++ b/tests/JTest.UnitTests/TestFileSearcherTests.cs
@@ -68,6 +68,28 @@ namespace JTest.UnitTests
         }
 
         [Fact]
+        public void When_Search_Then_MaintainsPatternArgumentOrder()
+        {
+            // Arrange
+            const string pattern1 = "TestFiles/TestSuites/test-file.json";
+            const string pattern2 = "TestFiles/TestSuites/test-file-with-categories.json";            
+
+            // Act
+            var result = TestFileSearcher.Search([pattern1, pattern2]);
+
+            // Assert
+            var resultFileNames = result.Select(Path.GetFileName);
+            Assert.Equal(
+               Path.GetFileName(pattern1),
+               resultFileNames.First()
+            );
+            Assert.Equal(
+               Path.GetFileName(pattern2),
+               resultFileNames.Last()
+            );
+        }
+
+        [Fact]
         public void When_Specifying_Categories_Then_Returns_Only_TestFiles_With_Categories()
         {
             // Arrange


### PR DESCRIPTION
Ordering of filter result was set to Ascending. This would cause issues especially from the CLI when users specify a list of test files, they expect the test files to be executed in that order.

Hence, each pattern is a test file input parameter, and each bulk  of test files returned by each of those parameters will be executed,

This way, the user is in full control over the ordering of sets/subsets of test files